### PR TITLE
chore: jx-test-quickstart-3 to 0.0.3

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.1
 - name: jx-test-quickstart-3
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.3
 - name: python-flask-docker
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
chore: Promote jx-test-quickstart-3 to version 0.0.3